### PR TITLE
Fix: MetaMask bug preventing connection on new tab sessions

### DIFF
--- a/src/ts/pages/home/home.ts
+++ b/src/ts/pages/home/home.ts
@@ -47,10 +47,20 @@ const render = async () => {
     buildComponent(root);
 };
 
-document.addEventListener("DOMContentLoaded", () => {
-    render()
-        .then(chainChangeEvent)
-        .catch((error) =>
-            console.error("An error occurred during rendering:", error)
-        );
-});
+// IIFE TO AVOID METAMASK BUG DISCUSSED HERE:
+// https://community.metamask.io/t/provider-not-getting-connected/27309/
+// https://community.metamask.io/t/provider-not-getting-connected/27309/10
+// (UGLY FIX) WILL BE REFACTORED AS SOON AS RELIABLE SOLUTION IS FOUND
+https: ((): void => {
+    if (!sessionStorage.getItem("blockioReload")) {
+        // To reload once
+        sessionStorage.setItem("blockioReload", "true");
+        window.location.reload();
+    }
+})();
+
+render()
+    .then(chainChangeEvent)
+    .catch((error) =>
+        console.error("An error occurred during rendering:", error)
+    );


### PR DESCRIPTION
Background:
When the website is first opened, an error might occur, where the MetaMask prevents connection and logs an error. If the page gets refreshed, everything starts working again. Likewise, opening a new tab with at least one tab already open also fixes the problem. Basically, this only happens when a new tab session is started.

Fix:
An "ugly fix" has been implemented where a reload is forced when a new tab session is established This will be refactored to a more reliable solution once one becomes available